### PR TITLE
Fixed seed hashing to use proper seed string

### DIFF
--- a/Assets/Scripts/Menus/CreateWorld.cs
+++ b/Assets/Scripts/Menus/CreateWorld.cs
@@ -100,7 +100,7 @@ public class CreateWorld : MonoBehaviour
             seed = seedBuilder.ToString();
         }
 
-        Hash128 hash = Hash128.Compute(worldSeedInput.text);
+        Hash128 hash = Hash128.Compute(seed);
         RandomStateWrapper randomStateWrapper = new(hash);
 
         string randomStateJson = JsonUtility.ToJson(randomStateWrapper);


### PR DESCRIPTION
Fixed random seeds not producing random worlds by making the hash use the seed string instead of the text input (which is always empty on random seeds)